### PR TITLE
Spotlight: fix for adding multiple items

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3079,11 +3079,11 @@
 				opacity: 1;
 			}
 
-		.spotlights > section:nth-child(2) {
+		.spotlights > section:nth-child(even) {
 			background-color: rgba(0, 0, 0, 0.05);
 		}
 
-		.spotlights > section:nth-child(3) {
+		.spotlights > section:nth-child(odd) {
 			background-color: rgba(0, 0, 0, 0.1);
 		}
 


### PR DESCRIPTION
When multiple items are added, spotlight features break.

This is a fix that keeps the changing background spotlight as and when one scroll on the page.